### PR TITLE
Prevent a similar sounding track from playing with album-first search (fallback to track search)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build/
 **/.DS_Store
 .idea/
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 **/.DS_Store
 .idea/
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cmake.sourceDirectory": "/home/krtirtho/dev/spotube-plugin-dab-music/example/linux"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cmake.sourceDirectory": "/home/krtirtho/dev/spotube-plugin-dab-music/example/linux"
-}

--- a/src/segments/audio_source.ht
+++ b/src/segments/audio_source.ht
@@ -66,7 +66,6 @@ class AudioSourceEndpoint {
     return s.toString().toLowerCase().trim()
   }
 
-  // Simple Levenshtein distance implementation
   fun _score(s1, s2) {
     var a = _cleanString(s1)
     var b = _cleanString(s2)

--- a/src/segments/audio_source.ht
+++ b/src/segments/audio_source.ht
@@ -58,16 +58,28 @@ class AudioSourceEndpoint {
       { type: "lossy", name: "mp3", qualities: [ { bitrate: 320000 } ] }.toJson(),
     ]
   }
-  
-  /// Find matching audio sources for a given track. It can return one or multiple matches.
-  /// The first match is considered the best match.
-  /// @param track - Map<SpotubeTrackObject>
-  /// @returns Future<List<SpotubeAudioSourceMatchObject>>
-  fun matches(track: Map) -> List {
-    final hasISRC = track["isrc"] != null && track["isrc"].isNotEmpty
-    var query = hasISRC ? track["isrc"] 
-      : "${track["name"]} ${track["artists"][0]["name"]}"
 
+  fun cleanString(s) {
+    if (s == null) {
+      return ""
+    }
+    return s.toString().toLowerCase().trim()
+  }
+
+  // Simple Levenshtein distance implementation
+  fun score(s1, s2) {
+    var a = cleanString(s1)
+    var b = cleanString(s2)
+    if (a == b) {
+      return 1.0
+    }
+    if (a.contains(b) || b.contains(a)) {
+      return 0.8
+    }
+    return 0.0
+  }
+  
+  fun searchTrack(query) {
     return api.get_req(
       "/search",
       queryParameters: {
@@ -75,20 +87,87 @@ class AudioSourceEndpoint {
         "type": "track",
         "limit": "5"
       }.toJson()
-    ).then((res) {
-      if(hasISRC && (res.data["tracks"] == null || res.data["tracks"].isEmpty)) {
-        return api.get_req(
-          "/search",
-          queryParameters: {
-            "q": "${track["name"]} ${track["artists"][0]["name"]}",
-            "type": "track",
-            "limit": "5"
-          }.toJson()
-        ).then((res)=> Converter.toSpotubeMatchObject(res.data["tracks"]))
-      }
-      
-      return Converter.toSpotubeMatchObject(res.data["tracks"])
-    })
+    ).then((res)=> Converter.toSpotubeMatchObject(res.data["tracks"]))
+  }
+
+  fun textSearch(trackName, artistName, albumName) {
+    if (albumName != null && albumName.isNotEmpty) {
+      return api.get_req(
+        "/search",
+        queryParameters: {
+          "q": "${albumName} ${artistName}",
+          "type": "album",
+          "limit": "1",
+        }.toJson()
+      ).then((res) {
+        if (res.data["albums"] != null && res.data["albums"].isNotEmpty) {
+          var album = res.data["albums"][0]
+          return api.get_req(
+            "/album",
+            queryParameters: {
+              "albumId": album["id"]
+            }.toJson()
+          ).then((details) {
+            var tracks = details.data["album"]["tracks"]
+            var bestTrack
+            var bestScore = 0.0
+
+            for (var t in tracks) {
+              var score = score(t["title"], trackName)
+              if (score > bestScore) {
+                bestScore = score
+                bestTrack = t
+              }
+            }
+
+            if (bestTrack != null && bestScore > 0.5) {
+              bestTrack["albumCover"] = album["albumCover"]
+              if (bestTrack["artist"] == null) {
+                bestTrack["artist"] = artistName
+              }
+
+              return Converter.toSpotubeMatchObject([bestTrack])
+            } else {
+              return searchTrack("${trackName} ${artistName}")
+            }
+          })
+        } else {
+          return searchTrack("${trackName} ${artistName}")
+        }
+      })
+    } else {
+      return searchTrack("${trackName} ${artistName}")
+    }
+  }
+
+  /// Find matching audio sources for a given track. It can return one or multiple matches.
+  /// The first match is considered the best match.
+  /// @param track - Map<SpotubeTrackObject>
+  /// @returns Future<List<SpotubeAudioSourceMatchObject>>
+  fun matches(track: Map) -> List {
+    final hasISRC = track["isrc"] != null && track["isrc"].isNotEmpty
+    var trackName = track["name"]
+    var artistName = track["artists"][0]["name"]
+    var albumName = track["album"] != null ? track["album"]["name"] : null
+
+    if (hasISRC) {
+      return api.get_req(
+        "/search",
+        queryParameters: {
+          "q": track["isrc"],
+          "type": "track",
+          "limit": "5",
+        }.toJson()
+      ).then((res) {
+        if(res.data["tracks"] != null && res.data["tracks"].isNotEmpty) {
+          return Converter.toSpotubeMatchObject(res.data["tracks"])
+        } else {
+          return textSearch(trackName, artistName, albumName)
+        }
+      })
+    }
+
+    return textSearch(trackName, artistName, albumName)
   }
 
   /// For the given match, return all available streams.

--- a/src/segments/audio_source.ht
+++ b/src/segments/audio_source.ht
@@ -59,7 +59,7 @@ class AudioSourceEndpoint {
     ]
   }
 
-  fun cleanString(s) {
+  fun _cleanString(s) {
     if (s == null) {
       return ""
     }
@@ -67,9 +67,9 @@ class AudioSourceEndpoint {
   }
 
   // Simple Levenshtein distance implementation
-  fun score(s1, s2) {
-    var a = cleanString(s1)
-    var b = cleanString(s2)
+  fun _score(s1, s2) {
+    var a = _cleanString(s1)
+    var b = _cleanString(s2)
     if (a == b) {
       return 1.0
     }
@@ -79,7 +79,7 @@ class AudioSourceEndpoint {
     return 0.0
   }
   
-  fun searchTrack(query) {
+  fun _searchTrack(query) {
     return api.get_req(
       "/search",
       queryParameters: {
@@ -87,10 +87,10 @@ class AudioSourceEndpoint {
         "type": "track",
         "limit": "5"
       }.toJson()
-    ).then((res)=> Converter.toSpotubeMatchObject(res.data["tracks"]))
+    ).then((res) => Converter.toSpotubeMatchObject(res.data["tracks"]))
   }
 
-  fun textSearch(trackName, artistName, albumName) {
+  fun _textSearch(trackName, artistName, albumName) {
     if (albumName != null && albumName.isNotEmpty) {
       return api.get_req(
         "/search",
@@ -110,17 +110,17 @@ class AudioSourceEndpoint {
           ).then((details) {
             var tracks = details.data["album"]["tracks"]
             var bestTrack
-            var bestScore = 0.0
+            var best_score = 0.0
 
             for (var t in tracks) {
-              var score = score(t["title"], trackName)
-              if (score > bestScore) {
-                bestScore = score
+              var score = _score(t["title"], trackName)
+              if (score > best_score) {
+                best_score = score
                 bestTrack = t
               }
             }
 
-            if (bestTrack != null && bestScore > 0.5) {
+            if (bestTrack != null && best_score > 0.5) {
               bestTrack["albumCover"] = album["albumCover"]
               if (bestTrack["artist"] == null) {
                 bestTrack["artist"] = artistName
@@ -128,15 +128,15 @@ class AudioSourceEndpoint {
 
               return Converter.toSpotubeMatchObject([bestTrack])
             } else {
-              return searchTrack("${trackName} ${artistName}")
+              return _searchTrack("${trackName} ${artistName}")
             }
           })
         } else {
-          return searchTrack("${trackName} ${artistName}")
+          return _searchTrack("${trackName} ${artistName}")
         }
       })
     } else {
-      return searchTrack("${trackName} ${artistName}")
+      return _searchTrack("${trackName} ${artistName}")
     }
   }
 
@@ -159,15 +159,15 @@ class AudioSourceEndpoint {
           "limit": "5",
         }.toJson()
       ).then((res) {
-        if(res.data["tracks"] != null && res.data["tracks"].isNotEmpty) {
+        if (res.data["tracks"] != null && res.data["tracks"].isNotEmpty) {
           return Converter.toSpotubeMatchObject(res.data["tracks"])
         } else {
-          return textSearch(trackName, artistName, albumName)
+          return _textSearch(trackName, artistName, albumName)
         }
       })
     }
 
-    return textSearch(trackName, artistName, albumName)
+    return _textSearch(trackName, artistName, albumName)
   }
 
   /// For the given match, return all available streams.

--- a/src/segments/audio_source.ht
+++ b/src/segments/audio_source.ht
@@ -11,7 +11,7 @@ class Converter {
         "id": d["id"].toString(),
         "title": d["title"],
         "artists": [d["artist"]],
-        "duration": d["duration"] * 1000,
+        "duration": (d["duration"] ?? 0) * 1000,
         "thumbnail": d["albumCover"],
         "externalUri": "https://dab.yeet.su/search?q=${d["title"]}%20${d["artist"]}",
       }.toJson()


### PR DESCRIPTION
This should fix #2. I already tested the plugin on my PC and phone.

As the title said, I made it search the album first. If no suitable match is found, it falls back into the original track search.

Thanks to @officiallor for the initial idea.